### PR TITLE
translate category on article page

### DIFF
--- a/springboard_iogt/filters.py
+++ b/springboard_iogt/filters.py
@@ -38,9 +38,9 @@ def category_dict(s_categories, uuids):
                 for category in categories)
 
 
-def content_section(obj):
+def content_section(obj, localizer=None):
     index = obj.es_meta.index if obj.es_meta else ''
     match = CONTENT_SECTION_SLUG_RE.search(index)
     if not match:
         return None
-    return ContentSection._for(match.group('slug'))
+    return ContentSection._for(match.group('slug'), localizer)

--- a/springboard_iogt/templates/page.jinja2
+++ b/springboard_iogt/templates/page.jinja2
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div>
-    {% set section = page|content_section %}
+    {% set section = page|content_section(request.localizer) %}
     {{ section_title(section) }}
 
     <div class="articles">

--- a/springboard_iogt/tests/test_filters.py
+++ b/springboard_iogt/tests/test_filters.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from mock import Mock
 
 from pyramid import testing
+from pyramid.i18n import make_localizer
 
 from springboard.tests import SpringboardTestCase
 from springboard.views.base import SpringboardViews
@@ -82,3 +83,18 @@ class TestFilters(SpringboardTestCase):
         section_obj = filters.content_section(page)
         self.assertEqual(section_obj.slug, 'ffl')
         self.assertEqual(section_obj.title, 'Facts For Life')
+
+    def test_content_section_translation(self):
+        localizer = make_localizer(
+            current_locale_name='fre_FR',
+            translation_directories=['springboard_iogt/locale']
+        )
+
+        [page] = self.mk_pages(self.workspace, count=1)
+        section_obj = filters.content_section(page, localizer)
+        self.assertIs(section_obj, None)
+
+        page.es_meta = Mock(index='unicore-cms-content-ffl-za-qa')
+        section_obj = filters.content_section(page, localizer)
+        self.assertEqual(section_obj.slug, 'ffl')
+        self.assertEqual(section_obj.title, 'Savoir pour Sauver')

--- a/springboard_iogt/utils.py
+++ b/springboard_iogt/utils.py
@@ -99,9 +99,9 @@ class ContentSection(object):
                 if cls.exists(section.get('name'), indexes)]
 
     @classmethod
-    def _for(cls, name):
+    def _for(cls, name, localizer=None):
         [obj] = [
-            cls(slug) for slug, data in cls.DATA.items()
+            cls(slug, localizer) for slug, data in cls.DATA.items()
             if data.get('name') == name]
         return obj
 


### PR DESCRIPTION
when viewing an article the link back to the category page was not being translated. This fixes that.
